### PR TITLE
Fix edit-time and infinte loop.

### DIFF
--- a/r2o.py
+++ b/r2o.py
@@ -56,6 +56,7 @@ def replace_blockrefs(s, uid2block, referenced_uids):
             uid = m.group(2)
             if uid not in uid2block:
                 print('************** uid not found:', uid)
+                break
             else:
                 referenced_uids.add(uid)
                 head = new_s[:m.start(1)]
@@ -119,7 +120,10 @@ pages = []
 
 for page in tqdm(j):
     title = page['title']
-    created = page.get('create-time', page['edit-time'])
+    if 'edit-time' in page.keys():
+        created = page.get('create-time', page['edit-time'])
+    else:
+        created = page.get('create-time', page['children'][0]['edit-time'])
     created = datetime.fromtimestamp(created/1000).isoformat()[:10]
     children = page.get('children', [])
 


### PR DESCRIPTION
Hi, thanks a lot for the script.
I found some error while converting mine database so I figure I would submit a PR.

The first one is the location of 'edit-time'. In some of my page, it's inside the `page['children'][0]` dict, in some other page it is directly in the `page` dict. I add a small `if else` around that.

The second one is infinite loop  when reference not found. I haven't dig around the logic around that part yet but just add a break statement seems to work fine for me.

Hope this help.